### PR TITLE
check for pull_request_target events as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,19 +17,20 @@ The id of the Work Item created
 
 3. Add a Secret named `AZURE_PERSONAL_ACCESS_TOKEN` containing an [Azure Personal Access Token](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate) with "read & write" permission for Work Items
 
-4. Add a workflow file which responds to Pull Requests, customizing the ORG_URL and PROJECT_NAME properties:
+4. Add a workflow file which responds to Pull Requests via `pull_request_target`, customizing the ORG_URL and PROJECT_NAME properties:
 
 ```yaml
 name: Check for vulnerabilities
 
 'on':
-  pull_request:
+  pull_request_target: 
     branches:
       - master
 
 jobs:
   alert:
     runs-on: ubuntu-latest
+    if: github.event.actor == 'dependabot[bot]'
     steps:
     - uses: peckjon/vulnerability-to-azure-board@master
       env:
@@ -38,3 +39,5 @@ jobs:
         ORG_URL: 'https://dev.azure.com/your_org_name'
         PROJECT_NAME: 'your_project_name'
 ```
+
+**NOTE**: The reason for using `pull_request_target` instead of generic `pull_request` is because of changes to allowing dependabot to read secrets ([Changelog](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/) and [Security details](https://securitylab.github.com/research/github-actions-preventing-pwn-requests)). Thus it is important to ensure that you use `pull_request_target` securely, and perhaps ensure that the person running the command is Dependabot. You may want to further restrict the running of the workflow with a conditional by ensuring it's only run when a label is applied like `if: contains(github.event.pull_request.labels.*.name, 'safe to test')`

--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ async function getVulnerabilities(context) {
 
 try {
   let context = github.context
-  if(context.eventName==`pull_request` && context.actor==`dependabot[bot]` && context.payload.pull_request.title.startsWith(`Bump `)) {
+  if((context.eventName==`pull_request` || context.eventName==`pull_request_target`) && context.actor==`dependabot[bot]` && context.payload.pull_request.title.startsWith(`Bump `)) {
     let [ ,depName, ,versionFrom, , versionTo] = context.payload.pull_request.title.split(` `);
     console.log(`Searching for Vulnerability Alerts with package name "${depName}" to patch to "${versionTo}"`);
     getVulnerabilities(context).then(vulnerabilities => {


### PR DESCRIPTION
Related to changes in https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/ but with caution: https://securitylab.github.com/research/github-actions-preventing-pwn-requests

Though this potentially introduces an issue with https://securitylab.github.com/research/github-actions-preventing-pwn-requests, we are further ensuring this check isn't run because of the `context.actor==dependabot[bot]` conditional.


TODO
- [x] Update readme to callout using `pull_request_target` and the risks.
- [x] perhaps suggestion to further check on the PRs to not execute their workflows at ALL unless the PR is opened from dependabot.